### PR TITLE
Removed Duplicate Dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,41 +56,34 @@
             <artifactId>spring-boot-starter-validation</artifactId>
         </dependency>
 
-		<dependency>
-			<groupId>com.fasterxml.jackson.core</groupId>
-			<artifactId>jackson-databind</artifactId>
-		</dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
 
-		<dependency>
-			<groupId>io.jsonwebtoken</groupId>
-			<artifactId>jjwt-impl</artifactId>
-			<version>0.11.5</version>
-		</dependency>
+        <!-- Enables serialization of LocalDate objects to JSON -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+            <version>2.17.2</version>
+        </dependency>
 
-		<dependency>
-			<groupId>io.jsonwebtoken</groupId>
-			<artifactId>jjwt-jackson</artifactId>
-			<version>0.11.5</version>
-		</dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-impl</artifactId>
+            <version>0.11.5</version>
+        </dependency>
 
-		<dependency>
-			<groupId>org.springframework.security</groupId>
-			<artifactId>spring-security-core</artifactId>
-		</dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-jackson</artifactId>
+            <version>0.11.5</version>
+        </dependency>
 
-		<!-- https://mvnrepository.com/artifact/junit/junit -->
-		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<version>4.13.1</version>
-			<scope>test</scope>
-		</dependency>
-
-		<dependency>
-			<groupId>com.fasterxml.jackson.datatype</groupId>
-			<artifactId>jackson-datatype-jsr310</artifactId>
-			<version>2.15.2</version> <!-- Use the appropriate version for your Jackson setup -->
-		</dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-core</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>org.postgresql</groupId>
@@ -114,10 +107,10 @@
 
         <!--- Swagger dependency -->
         <dependency>
-			<groupId>org.springdoc</groupId>
-			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-			<version>2.6.0</version>
-		</dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>2.6.0</version>
+        </dependency>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -136,6 +129,7 @@
             <artifactId>h2</artifactId>
             <scope>test</scope>
         </dependency>
+
         <!-- https://mvnrepository.com/artifact/com.stripe/stripe-java -->
         <dependency>
             <groupId>com.stripe</groupId>
@@ -152,13 +146,6 @@
             <groupId>org.springframework.kafka</groupId>
             <artifactId>spring-kafka-test</artifactId>
             <scope>test</scope>
-        </dependency>
-
-        <!-- https://mvnrepository.com/artifact/com.fasterxml.jackson.datatype/jackson-datatype-jsr310 -->
-        <dependency>
-            <groupId>com.fasterxml.jackson.datatype</groupId>
-            <artifactId>jackson-datatype-jsr310</artifactId>
-            <version>2.17.2</version>
         </dependency>
 
     </dependencies>

--- a/src/test/java/com/revlearn/team1/unit/dto/UserDTOTest.java
+++ b/src/test/java/com/revlearn/team1/unit/dto/UserDTOTest.java
@@ -1,8 +1,9 @@
 package com.revlearn.team1.unit.dto;
 
 import com.revlearn.team1.dto.user.UserDTO;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class UserDTOTest {
     UserDTO userDTO = new UserDTO("username", "password");
@@ -10,7 +11,7 @@ public class UserDTOTest {
     @Test
     public void testToString() throws Exception {
         String expected = "LoginRequest{username='username', password='password'}";
-        Assert.assertEquals(expected, userDTO.toString());
+        assertEquals(expected, userDTO.toString());
     }
 }
 

--- a/src/test/java/com/revlearn/team1/unit/service/UserServiceTest.java
+++ b/src/test/java/com/revlearn/team1/unit/service/UserServiceTest.java
@@ -4,19 +4,19 @@ import com.revlearn.team1.enums.Roles;
 import com.revlearn.team1.model.User;
 import com.revlearn.team1.repository.UserRepository;
 import com.revlearn.team1.service.user.UserServiceImp;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.junit.jupiter.api.Test;
 
 import java.time.LocalDateTime;
 import java.time.Month;
 import java.util.Optional;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.*;
 
@@ -28,7 +28,7 @@ public class UserServiceTest {
     @InjectMocks
     UserServiceImp userService;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         MockitoAnnotations.openMocks(this);
     }
@@ -51,7 +51,7 @@ public class UserServiceTest {
         when(userRepository.findByUsername(username)).thenReturn(Optional.of(user));
 
         UserDetails result = userService.loadUserByUsername(username);
-        Assert.assertEquals(user, result);
+        assertEquals(user, result);
     }
 
     private User createUser(String username) {


### PR DESCRIPTION
- Removed JUnit 4 was because JUnit 5 is included in spring-boot-starter-test
- Updated affected tests from JUnit 4 syntax to JUnit 5 syntax.
- Removed lower version entry of duplicated jackson jsr310 (serializes LocalDate objects to JSON)

Tried to resolve a test warning, but it seems like an upstream Kafka issue that is addressed in the next version.
`WARNING: Discovered 2 'junit-platform.properties' configuration files in the classpath; only the first will be used.`

- https://github.com/spring-projects/spring-boot/issues/41446
- https://issues.apache.org/jira/projects/KAFKA/issues/KAFKA-17121?filter=allissues
- https://github.com/ksolves/kafka/commit/f05d10110bc9c32573bfa96a1c68bdeb6b200784
